### PR TITLE
Fix build failure on Linux amd64 with gcc 7

### DIFF
--- a/src/ffi_stub_linux64.s
+++ b/src/ffi_stub_linux64.s
@@ -162,15 +162,15 @@ sse_done:
     ret
 
 c_callback_stub_double_x64:
-    movq        $c_callback_double_x64, %r11
+    movq        c_callback_double_x64@GOTPCREL(%rip), %r11
     jmp         callback_stub_common
 
 c_callback_stub_float_x64:
-    movq        $c_callback_float_x64, %r11
+    movq        c_callback_float_x64@GOTPCREL(%rip), %r11
     jmp         callback_stub_common
 
 c_callback_stub_intptr_x64:
-    movq        $c_callback_intptr_x64, %r11
+    movq        c_callback_intptr_x64@GOTPCREL(%rip), %r11
     jmp         callback_stub_common
 
 callback_stub_common:


### PR DESCRIPTION
Hello!

I was unable to compile Ypsilon on Debian amd64 unstable:

/usr/bin/ld: ffi_stub_linux64.o: relocation R_X86_64_32S against symbol `c_callback_double_x64' can not be used when making a shared object; recompile with -fPIC

Please review this fix.

/Göran