### PR TITLE
Add missing leap seconds in SRFI-19

### DIFF
--- a/sitelib/srfi/19.scm
+++ b/sitelib/srfi/19.scm
@@ -342,7 +342,11 @@
 ;; each entry is ( utc seconds since epoch . # seconds to add for tai )
 ;; note they go higher to lower, and end in 1972.
   (define tm:leap-second-table
-    '((1136073600 . 33)
+    '((1483228800 . 37)
+      (1435708800 . 36)
+      (1341100800 . 35)
+      (1230768000 . 34)
+      (1136073600 . 33)
       (915148800 . 32)
       (867715200 . 31)
       (820454400 . 30)


### PR DESCRIPTION
There have been five leap seconds introduced since the last update to the table in SRFI-19. It currently appears that no new leap seconds will be introduced.