### PR TITLE
Export map from SRFI-1

### DIFF
--- a/sitelib/srfi/1.scm
+++ b/sitelib/srfi/1.scm
@@ -62,6 +62,7 @@
           reduce-right
           append-map
           (rename append-map append-map!)
+          map
           map!
           pair-for-each
           filter-map


### PR DESCRIPTION
I was running akku-r7rs on Ypsilon. It imports some procedures from srfi-1 using "only", and since map is one of them it errors.